### PR TITLE
Added Kerberos authentication option via GSSAPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='adidnsdump',
       author_email='dirkjan@dirkjanm.io',
       url='https://github.com/dirkjanm/adidnsdump',
       packages=['adidnsdump'],
-      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6'],
+      install_requires=['impacket', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'dnspython', 'gssapi'],
       entry_points={
           'console_scripts': ['adidnsdump=adidnsdump:main']
       }


### PR DESCRIPTION
Quick and dirty way for kerberos auth. I tested the tool in the W200 lab and it worked fine. When using  -k, you can omit the username and it will parse the CCACHE file. 

<img width="1054" height="544" alt="image" src="https://github.com/user-attachments/assets/45d72822-e984-44a8-a2cc-aa21003cc833" />
